### PR TITLE
Fix: pass block id to get_account()

### DIFF
--- a/thor_requests/connect.py
+++ b/thor_requests/connect.py
@@ -93,7 +93,7 @@ class Connect:
         int
             The balance of the VET in Wei
         """
-        account_status = self.get_account(address)
+        account_status = self.get_account(address, block)
         return int(account_status["balance"], 16)
 
     def get_vtho_balance(self, address: str, block: str = "best") -> int:
@@ -112,7 +112,7 @@ class Connect:
         int
             The balance of the VTHO in Wei
         """
-        account_status = self.get_account(address)
+        account_status = self.get_account(address, block)
         return int(account_status["energy"], 16)
 
     def get_block(self, id_or_number: str = "best", expanded: bool = False) -> dict:


### PR DESCRIPTION
Fix a bug where the functions `Connect.get_vtho_balance` &
`Connect.get_vet_balance` receive the desired block height as a parameter,
but do not pass it forward to `Connect.get_account()`.